### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = false
+
+[{.*,*.md,*.json,*.toml,*.yml,}]
+indent_style = space


### PR DESCRIPTION
Working on the "err on the side of do" principle:

- taken directly from [withastro/astro](https://github.com/withastro/astro/blob/main/.editorconfig) project
- should solve the eol problems, tab, space, and eof new line for all new files edited or worked on.
- recommending to add `editorconfig.editorconfig` to your vs-code to pick up editorconfig settings automatically. 
- check for native compatibility with editors [here](https://editorconfig.org/#pre-installed)

Just wanted to jump in a provide a soft assist with this configuration. 
If this is not useful at this moment go ahead and discard. 